### PR TITLE
Fix for POTCAR override parsing from vise.yaml

### DIFF
--- a/vise/cli/main_tools.py
+++ b/vise/cli/main_tools.py
@@ -17,6 +17,7 @@ def potcar_str2dict(potcar_list: Union[str, List[str], None]) -> dict:
     If potcar_dict is None, {} is returned.
     Examples
         ["Mg_pv", O_h"] -> {"Mg": "Mg_pv", "O": "O_h"}
+        "Mg_pv O_h" -> {"Mg": "Mg_pv", "O": "O_h"}
         "Mg_pv" -> {"Mg": "Mg_pv"}
         None -> {}
 
@@ -31,7 +32,7 @@ def potcar_str2dict(potcar_list: Union[str, List[str], None]) -> dict:
     if potcar_list is None:
         return {}
     elif isinstance(potcar_list, str):
-        potcar_list = [potcar_list]
+        potcar_list = potcar_list.split()
 
     d = {}
     for p in potcar_list:


### PR DESCRIPTION
Dear Prof. Kumagai,

While attempting to override POTCAR types using the `vise.yaml` configuration as documented (`overridden_potcar: Mg_pv O_h`), I encountered the following runtime error:

```
RuntimeError: You do not have the right POTCAR with functional='PBE_54' and symbol='Mg_pv O_h' in your PMG_VASP_PSP_DIR='~/psuedopot1'. Paths tried: ['~/psuedopot1/POT_GGA_PAW_PBE_54/POTCAR.Mg_pv O_h', '~/psuedopot1/POT_GGA_PAW_PBE_54/Mg_pv O_h/POTCAR']
```

Interestingly, overriding a single POTCAR type (`overridden_potcar: Mg_pv`) works without issue. Additionally, using the `--potcar` command-line argument successfully applies multiple overrides.

Upon investigation, I found that the issue stems from how the `overridden_potcar` value is parsed. When read from `vise.yaml`, it is interpreted as a single string, whereas the command-line argument is parsed as a list. The current `potcar_str2dict` function handles lists and single strings correctly, but fails when space-separated POTCAR types are provided as a single string—exactly the case when reading from `vise.yaml`.

This pull request introduces a small fix to ensure that space-separated POTCAR strings from `vise.yaml` are correctly parsed into a list before being processed, resolving the runtime error.

Best regards,  
Shibu Meher