### PR TITLE
Minor refactoring to ensure full compatibility with `pymatgen-core` (only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation instructions
   - Python 3.7 or higher
 
 Vise depends largely on the following packages, which should be acknowledged sincerely,
-  - pymatgen
+  - pymatgen-core
   - spglib
   - seekpath
   - see requirements.txt for others

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymatgen
+pymatgen-core
 seekpath
 num2words
 more_itertools

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,6 @@ from vise import __version__
 module_dir = os.path.dirname(os.path.abspath(__file__))
 reqs_raw = open(os.path.join(module_dir, "requirements.txt")).read()
 reqs_list = [r.replace("==", "~=") for r in reqs_raw.split("\n")]
-#reqs_list = [r for r in reqs_raw.split("\n")]
-
-# try:
-#     from Cython.Distutils import build_ext
-# except ImportError:
-#     use_cython = False
-# else:
-#     use_cython = True
 
 cmdclass = {}
 ext_modules = []

--- a/vise/tests/analyzer/test_dielectric_function.py
+++ b/vise/tests/analyzer/test_dielectric_function.py
@@ -77,7 +77,7 @@ def test_to_csv_file(tmpdir):
     actual = Path("diele_func_data.csv").read_text()
     expected = """energies(eV),real_xx,real_yy,real_ave,imag_xx,imag_yy,imag_ave,absorption_xx,absorption_yy,absorption_ave,band_gap
 0.0,0.1,0.2,0.3,1.1,1.2,1.3,0.0,0.0,0.0,1.0
-3.0,0.1,0.2,0.3,1.1,1.2,1.3,215492.69716617066,216777.74282824568,218647.7413198019,
+3.0,0.1,0.2,0.3,1.1,1.2,1.3,215492.69717550077,216777.7428376314,218647.7413292686,
 """
     assert actual == expected
 

--- a/vise/tests/helpers/assertion.py
+++ b/vise/tests/helpers/assertion.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from monty.json import MSONable
 from monty.serialization import loadfn
 import numpy as np
-from pymatgen.analysis.structure_matcher import StructureMatcher, \
+from pymatgen.core.structure_matcher import StructureMatcher, \
     ElementComparator
 from pymatgen.core import IStructure
 from vise.util.mix_in import ToYamlFileMixIn


### PR DESCRIPTION
This PR introduces some minor refactoring so that `vise` is directly dependent on only `pymatgen-core` (https://github.com/materialsproject/pymatgen-core – recently separated from the full `pymatgen` package to reduce the package size and demarcate internally-maintained code from community-maintained code).